### PR TITLE
Add the missing rependency on readr

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -3,7 +3,7 @@ Title: What the Package Does (one line, title case)
 Version: 0.0.0.9000
 Authors@R: person("Josiah", "Parry", email = "josiah.parry@yahoo.com", role = c("aut", "cre"))
 Description: Easily access song lyrics in a tidy way.
-Depends: R (>= 3.4.0), dplyr
+Depends: R (>= 3.4.0), dplyr, readr
 License: What license is it under?
 Encoding: UTF-8
 LazyData: true

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -3,7 +3,7 @@ Title: What the Package Does (one line, title case)
 Version: 0.0.0.9000
 Authors@R: person("Josiah", "Parry", email = "josiah.parry@yahoo.com", role = c("aut", "cre"))
 Description: Easily access song lyrics in a tidy way.
-Depends: R (>= 3.4.0), dplyr, readr
+Depends: R (>= 3.4.0), dplyr, readr, rvest, tidyr
 License: What license is it under?
 Encoding: UTF-8
 LazyData: true


### PR DESCRIPTION
readr is mentioned in NAMESPACE

I don't really know what I'm doing here, but `devtools::install_github("josiahparry/geniusR")` ended with

```
** byte-compile and prepare package for lazy loading
Error in loadNamespace(j <- i[[1L]], c(lib.loc, .libPaths()), versionCheck = vI[[j]]) : 
  there is no package called ‘readr’
ERROR: lazy loading failed for package ‘geniusR’
```

and `install.packages("readr")` fixed it... almost, then rvest and tidyr for real.

I am using R 3.5.1 from openSUSE's Education repo: https://build.opensuse.org/package/show/Education/R-base