### PR TITLE
fixes missing lyrics issue #58

### DIFF
--- a/R/genius_url.R
+++ b/R/genius_url.R
@@ -45,7 +45,7 @@ genius_url <- function(url, info = "title")  {
   # scrape the lyrics
   lyrics <- # read the text from the lyrics class
     # read the text from the lyrics class
-    html_node(genius_session, ".Lyrics__Container-sc-1ynbvzw-6") %>%
+    html_node(genius_session, ".Lyrics__Container-sc-1ynbvzw-7") %>%
     # trim white space
     html_text(trim = TRUE) %>%
     # use named vector for cleaning purposes


### PR DESCRIPTION
Genius updated their lyrics page layout and switched the class of the element where the lyrics are stored from `Lyrics__Container-sc-1ynbvzw-6` to `Lyrics__Container-sc-1ynbvzw-7`. Changing `genius_url()` to match should fix the missing lyrics issue described in issue #58.


--
PS. Sorry for the literal one character change pull request, I was just also running into the lyrics issue as well and wanted to dig in and help out.